### PR TITLE
Polar, smear, and axisymmetry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@
  - Restructure into python package
  - Added `Kinematics` class for presenting the data to be modeled
  - Added the MaNGA-specific I/O objects that subclass from `Kinematics`
- - Changes the geometry computatio; see `barfit.models.geometry`
+ - Changes the geometry computation; see `barfit.models.geometry`
  - Speeds up the beam-smearing convolution, and checks that the
    convolution with the MaNGA PSF does not shift the model
  - Dramatically speeds up the `Kinematics.bin` function using

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,4 +7,11 @@
  - Restructure into python package
  - Added `Kinematics` class for presenting the data to be modeled
  - Added the MaNGA-specific I/O objects that subclass from `Kinematics`
+ - Changes the geometry computatio; see `barfit.models.geometry`
+ - Speeds up the beam-smearing convolution, and checks that the
+   convolution with the MaNGA PSF does not shift the model
+ - Dramatically speeds up the `Kinematics.bin` function using
+   `scipy.sparse` matrices.
+ - Adds a bunch of test code.
+ - Begins the implementation of a general `AxisymmetricDisk` class.
 

--- a/barfit/barfit.py
+++ b/barfit/barfit.py
@@ -59,7 +59,8 @@ from .models.geometry import projected_polar
 #    th = (np.pi/2 - np.arctan2(yd,xd)) % (np.pi*2)
 #    return r, th 
 
-# Moved to barfit/models/axisym.py
+
+#  Moved to barfit.models.axisym.rotcurveeval, but with some changes
 #def rotcurveeval(x,y,vmax,inc,pa,h,vsys=0,xc=0,yc=0,reff=1):
 #    '''
 #    Evaluate a simple tanh rotation curve with asymtote vmax, inclination inc
@@ -69,11 +70,10 @@ from .models.geometry import projected_polar
 #    '''
 #
 #    inc, pa = np.radians([inc,pa])
-#    r,th = projected_polar(x-xc,y-yc, pa, inc)
-#    r /= reff
-#    # TODO: Why was there a negative here? (it used to be `-vmax`)
-#    model = vmax * np.tanh(r/h) * np.cos(th) * np.sin(inc) + vsys
+#    r,th = polar(x-xc,y-yc,inc,pa,reff)
+#    model = -vmax * np.tanh(r/h) * np.cos(th) * np.sin(inc) + vsys
 #    return model
+
 
 def barmodel(args,inc,pa,pab,vsys,vts,v2ts,v2rs,xc=0,yc=0,plot=False):
     '''

--- a/barfit/barfit.py
+++ b/barfit/barfit.py
@@ -10,12 +10,14 @@ spekkens code pitfalls
 '''
 
 import sys
+import argparse
 import multiprocessing as mp
 
+from IPython import embed
+
 import numpy as np
-from scipy.optimize import leastsq
-from scipy.signal import convolve
 from scipy import stats
+
 import matplotlib.pyplot as plt
 
 from astropy.io import fits
@@ -25,42 +27,53 @@ try:
 except:
     tqdm = None
 
-import emcee
-import ptemcee
-import dynesty
-import argparse
+try:
+    import emcee
+except:
+    emcee = None
 
-from .beam_smearing import apply_beam_smearing as smear
-from .galaxy import Galaxy
-from .data.kinematics import Kinematics
+try:
+    import ptemcee
+except:
+    ptemcee = None
+
+import dynesty
+
+from .models.beam import smear
 from .data.manga import MaNGAGasKinematics, MaNGAStellarKinematics
 from .data.fitargs import FitArgs
 
-def polar(x,y,i,pa,reff=1): 
-    '''
-    Transform x,y coordinates from Cartesian to polar coordinates rotated at
-    angle pa and inclination i. Returns radial coordinate r and aziumuthal
-    coordinate pa. All angles in radians.  
-    '''
+from .models.geometry import projected_polar
 
-    yd = (x*np.cos(pa) + y*np.sin(pa))
-    xd = (y*np.cos(pa) - x*np.sin(pa))/np.cos(i) 
-    r = np.sqrt(xd**2 + yd**2) / reff
-    th = (np.pi/2 - np.arctan2(yd,xd)) % (np.pi*2)
-    return r, th 
+# Now barfit.models.geometry.projected_polar, but with some changes.
+#def polar(x,y,i,pa,reff=1): 
+#    '''
+#    Transform x,y coordinates from Cartesian to polar coordinates rotated at
+#    angle pa and inclination i. Returns radial coordinate r and aziumuthal
+#    coordinate pa. All angles in radians.  
+#    '''
+#
+#    yd = (x*np.cos(pa) + y*np.sin(pa))
+#    xd = (y*np.cos(pa) - x*np.sin(pa))/np.cos(i) 
+#    r = np.sqrt(xd**2 + yd**2) / reff
+#    th = (np.pi/2 - np.arctan2(yd,xd)) % (np.pi*2)
+#    return r, th 
 
-def rotcurveeval(x,y,vmax,inc,pa,h,vsys=0,xc=0,yc=0,reff=1):
-    '''
-    Evaluate a simple tanh rotation curve with asymtote vmax, inclination inc
-    in degrees, position angle pa in degrees, rotation scale h, systematic
-    velocity vsys, and x and y offsets xc and yc. Returns array in same shape
-    as input x andy.
-    '''
-
-    inc, pa = np.radians([inc,pa])
-    r,th = polar(x-xc,y-yc,inc,pa,reff)
-    model = -vmax * np.tanh(r/h) * np.cos(th) * np.sin(inc) + vsys
-    return model
+# Moved to barfit/models/axisym.py
+#def rotcurveeval(x,y,vmax,inc,pa,h,vsys=0,xc=0,yc=0,reff=1):
+#    '''
+#    Evaluate a simple tanh rotation curve with asymtote vmax, inclination inc
+#    in degrees, position angle pa in degrees, rotation scale h, systematic
+#    velocity vsys, and x and y offsets xc and yc. Returns array in same shape
+#    as input x andy.
+#    '''
+#
+#    inc, pa = np.radians([inc,pa])
+#    r,th = projected_polar(x-xc,y-yc, pa, inc)
+#    r /= reff
+#    # TODO: Why was there a negative here? (it used to be `-vmax`)
+#    model = vmax * np.tanh(r/h) * np.cos(th) * np.sin(inc) + vsys
+#    return model
 
 def barmodel(args,inc,pa,pab,vsys,vts,v2ts,v2rs,xc=0,yc=0,plot=False):
     '''
@@ -75,8 +88,8 @@ def barmodel(args,inc,pa,pab,vsys,vts,v2ts,v2rs,xc=0,yc=0,plot=False):
 
     #convert angles to polar and normalize radial coorinate
     inc,pa,pab = np.radians([inc,pa,pab])
-    r, th = polar(args.grid_y-xc,args.grid_x-yc,inc,pa,args.reff)
-
+    r, th = projected_polar(args.grid_x-xc,args.grid_y-yc,pa,inc)
+    r /= args.reff
     #interpolate velocity values for all r 
     bincents = (args.edges[:-1] + args.edges[1:])/2
     vtvals = np.interp(r,bincents,vts)
@@ -85,11 +98,12 @@ def barmodel(args,inc,pa,pab,vsys,vts,v2ts,v2rs,xc=0,yc=0,plot=False):
 
     #spekkens and sellwood 2nd order vf model (from andrew's thesis)
     model = vsys + np.sin(inc) * (vtvals*np.cos(th) - v2tvals*np.cos(2*(th-pab))*np.cos(th)- v2rvals*np.sin(2*(th-pab))*np.sin(th))
-    if args.smear:
-        model = smear(model, args.psf, args.sb_r, args.sig_r, mask=args.vel_mask_r)[1]
-
-    if plot: return model
-    return args.bin(model)
+    if args.beam_fft is not None:
+        model = smear(model, args.beam_fft, beam_fft=True)[1]
+#        smear(model, args.psf, args.sb_r, args.sig_r, mask=args.vel_mask_r)[1]
+    if plot:
+        return args.remap_data(np.ma.MaskedArray(model, mask=args.vel_mask), masked=True)
+    return np.ma.MaskedArray(args.bin(model), mask=args.vel_mask)
 
 def unpack(params, nglobs):
     '''
@@ -200,12 +214,11 @@ def loglike(params, args):
     field with current parameter vales and performs a chi squared on it across
     the whole vf weighted by ivar to get a log likelihood value. 
     '''
-
     inc,pa,pab,vsys,xc,yc,vts,v2ts,v2rs = unpack(params,args.nglobs)
 
     #make vf model and perform chisq
     vfmodel = barmodel(args,inc,pa,pab,vsys,vts,v2ts,v2rs,xc,yc)
-    llike = -.5*np.sum((vfmodel - args.vel)**2 * args.vel_ivar) #chisq
+    llike = -.5*np.ma.sum((vfmodel - args.vel)**2 * args.vel_ivar) #chisq
     #llike -= args.weight * (smoothing(vts) - smoothing(v2ts) - smoothing(v2rs))
     llike = llike - smoothing(vts,args.weight) - smoothing(v2ts,args.weight) - smoothing(v2rs,args.weight)
     return llike
@@ -222,8 +235,9 @@ def logpost(params, args):
     llike = loglike(params, args)
     return lprior + llike
 
-def barfit(plate,ifu, nbins=10, cores=20, walkers=100, steps=1000, maxr=1.5,
-        ntemps=None, cen=False,start=False,dyn=True,weight=10,smearing=True,points=500,stellar=False):
+def barfit(plate, ifu, daptype='HYB10-MILESHC-MASTARHC', dr='MPL-9', nbins=10, cores=20,
+           walkers=100, steps=1000, maxr=1.5, ntemps=None, cen=False, start=False, dyn=True,
+           weight=10, smearing=True, points=500, stellar=False, root=None, verbose=False):
     '''
     Main function for velocity field fitter. Takes a given plate and ifu and
     fits a nonaxisymmetric velocity field with nbins number of radial bins
@@ -238,14 +252,21 @@ def barfit(plate,ifu, nbins=10, cores=20, walkers=100, steps=1000, maxr=1.5,
     '''
 
     #get info on galaxy and define bins and starting guess
-    if stellar: args = MaNGAStellarKinematics.from_plateifu(plate,ifu)
-    else: args = MaNGAGasKinematics.from_plateifu(plate,ifu,line='Ha-6564',daptype='HYB10-MILESHC-MASTARHC',dr='MPL-9')
+    if stellar:
+        args = MaNGAStellarKinematics.from_plateifu(plate, ifu, daptype=daptype, dr=dr,
+                                                    ignore_psf=not smearing, cube_path=root,
+                                                    maps_path=root)
+    else:
+        args = MaNGAGasKinematics.from_plateifu(plate, ifu, line='Ha-6564', daptype=daptype,
+                                                dr=dr, ignore_psf=not smearing, cube_path=root,
+                                                maps_path=root)
+
     args.setnglobs(6) if cen else args.setnglobs(4)
     args.setedges(nbins, maxr)
     args.setweight(weight)
-    args.setsmear(smearing)
+#    args.setsmear(smearing)
 
-    if smearing: [args.remap(a) for a in ['sb', 'sig', 'vel_mask']]
+#    if smearing: [args.remap(a) for a in ['sb', 'sig', 'vel_mask']]
     theta0 = args.getguess()
 
     #open up multiprocessing pool if needed
@@ -259,16 +280,20 @@ def barfit(plate,ifu, nbins=10, cores=20, walkers=100, steps=1000, maxr=1.5,
         #dynesty sampler with periodic pa and pab
         sampler = dynesty.NestedSampler(loglike,dynprior,len(theta0),pool=pool,
                 periodic=[1,2], nlive=points,# queue_size=cores, 
-                ptform_args = [args], logl_args = [args])
+                ptform_args = [args], logl_args = [args], verbose=verbose)
         sampler.run_nested()
     
     else:
         if ntemps:
+            if ptemcee is None:
+                raise ImportError('ptemcee is not available.  Run pip install ptemcee and rerun.')
             #parallel tempered MCMC using somewhat outdated ptemcee
             pos = 1e-4*np.random.randn(ntemps,walkers,len(theta0)) + theta0
             sampler = ptemcee.Sampler(walkers, len(theta0), loglike, logprior, loglargs=[args], logpargs=[args], threads=cores, ntemps=ntemps)
 
         else:
+            if emcee is None:
+                raise ImportError('emcee is not available.  Run pip install emcee and rerun.')
             #normal MCMC with emcee
             if type(start) != bool:
                 #set starting positions if given
@@ -291,3 +316,6 @@ def barfit(plate,ifu, nbins=10, cores=20, walkers=100, steps=1000, maxr=1.5,
 
     if cores > 1 and not ntemps: pool.close()
     return sampler
+
+
+

--- a/barfit/barfit.py
+++ b/barfit/barfit.py
@@ -218,7 +218,11 @@ def loglike(params, args):
 
     #make vf model and perform chisq
     vfmodel = barmodel(args,inc,pa,pab,vsys,vts,v2ts,v2rs,xc,yc)
-    llike = -.5*np.ma.sum((vfmodel - args.vel)**2 * args.vel_ivar) #chisq
+    # vfmodel is masked
+    llike = (vfmodel - args.vel)**2
+    if args.vel_ivar is not None:
+        llike *= args.vel_ivar
+    llike = -.5*np.ma.sum(llike) #chisq
     #llike -= args.weight * (smoothing(vts) - smoothing(v2ts) - smoothing(v2rs))
     llike = llike - smoothing(vts,args.weight) - smoothing(v2ts,args.weight) - smoothing(v2rs,args.weight)
     return llike

--- a/barfit/data/fitargs.py
+++ b/barfit/data/fitargs.py
@@ -66,6 +66,9 @@ class FitArgs:
         pa %= 360
         vmax,inc,h = np.abs([vmax,inc,h])
 
+        embed()
+        exit()
+
         #generate model of vf and start assembling array of guess values
         model = rotcurveeval(self.grid_x,self.grid_y,vmax,inc,pa,h,vsys,reff=self.reff)
         guess = [inc,pa,pa,vsys,0,0,0]

--- a/barfit/data/fitargs.py
+++ b/barfit/data/fitargs.py
@@ -66,9 +66,6 @@ class FitArgs:
         pa %= 360
         vmax,inc,h = np.abs([vmax,inc,h])
 
-        embed()
-        exit()
-
         #generate model of vf and start assembling array of guess values
         model = rotcurveeval(self.grid_x,self.grid_y,vmax,inc,pa,h,vsys,reff=self.reff)
         guess = [inc,pa,pa,vsys,0,0,0]

--- a/barfit/data/fitargs.py
+++ b/barfit/data/fitargs.py
@@ -1,7 +1,13 @@
 #!/usr/bin/env python
 
+from IPython import embed
+
 import numpy as np
+from scipy.optimize import leastsq
 import matplotlib.pyplot as plt
+
+from ..models.geometry import projected_polar
+from ..models.axisym import rotcurveeval
 
 class FitArgs:
     '''
@@ -31,12 +37,12 @@ class FitArgs:
 
         self.edges = np.linspace(0,maxr,nbins+1)
 
-    def setsmear(self, smear):
-        '''
-        Set whether or not to do beam smearing. Should only provide True or False
-        '''
-
-        self.smear = smear
+#    def setsmear(self, smear):
+#        '''
+#        Set whether or not to do beam smearing. Should only provide True or False
+#        '''
+#
+#        self.smear = smear
 
     def getguess(self):
         '''
@@ -47,9 +53,6 @@ class FitArgs:
         parameter in format [inc,pa,pab,vsys] + [vt,v2t,v2r]*(number of bins).
         Inc and pa in degrees. Assumes pab = pa.
         '''
-        from barfit.barfit import polar,rotcurveeval
-        from scipy.optimize import leastsq
-
         if self.edges is None: raise ValueError('Must define edges first')
 
         #define a minimization function and feed it to simple leastsquares
@@ -66,7 +69,8 @@ class FitArgs:
         #generate model of vf and start assembling array of guess values
         model = rotcurveeval(self.grid_x,self.grid_y,vmax,inc,pa,h,vsys,reff=self.reff)
         guess = [inc,pa,pa,vsys,0,0,0]
-        r,th = polar(self.grid_y, self.grid_x, inc, pa, reff=self.reff)
+        r,th = projected_polar(self.grid_x, self.grid_y, *np.radians([pa,inc]))
+        r /= self.reff
 
         #iterate through bins and get vt value for each bin, 
         #dummy value for v2t and v2r since there isn't a good guess

--- a/barfit/data/kinematics.py
+++ b/barfit/data/kinematics.py
@@ -286,6 +286,7 @@ class Kinematics(FitArgs):
 
         # Set the error and incorporate the mask for a masked array
         if ivar is None:
+            # Don't instantiate the array if we don't need to.
             _ivar = None #np.ones(self.spatial_shape, dtype=float)
         elif isinstance(ivar, np.ma.MaskedArray):
             _mask |= np.ma.getmaskarray(ivar)
@@ -293,7 +294,8 @@ class Kinematics(FitArgs):
         else:
             _ivar = ivar
         # Make sure to mask any measurement with ivar <= 0
-        _mask |= np.logical_not(_ivar > 0)
+        if _ivar is not None:
+            _mask |= np.logical_not(_ivar > 0)
 
         return _data, _ivar, _mask
 

--- a/barfit/data/kinematics.py
+++ b/barfit/data/kinematics.py
@@ -297,10 +297,11 @@ class Kinematics(FitArgs):
 
         return _data, _ivar, _mask
 
-    def remap_data(self, data):
+    def remap_data(self, data, masked=False):
         if data.shape != self.vel.shape:
             raise ValueError('To remap, must have the same shape as the internal data attributes.')
-        _data = np.zeros(self.spatial_shape, dtype=float)
+        _data = np.ma.masked_all(self.spatial_shape, dtype=float) \
+                    if masked else np.zeros(self.spatial_shape, dtype=float)
         _data[np.unravel_index(self.grid_indx, self.spatial_shape)] = data[self.bin_inverse]
         return _data
 

--- a/barfit/data/kinematics.py
+++ b/barfit/data/kinematics.py
@@ -19,8 +19,11 @@ model.
 from IPython import embed
 
 import numpy as np
+from scipy import sparse
+
 from .fitargs import FitArgs
 
+from ..models.beam import construct_beam
 
 class Kinematics(FitArgs):
     r"""
@@ -161,9 +164,7 @@ class Kinematics(FitArgs):
 
         # Basic properties
         self.spatial_shape = vel.shape
-
-        self.psf = psf
-        self.aperture = aperture
+        self._set_beam(psf, aperture)
         self.reff = reff
 
         # Build coordinate arrays
@@ -231,17 +232,39 @@ class Kinematics(FitArgs):
             # bin numbers are not sequential, i.e., the bin numbers are
             # not identical to np.arange(nbin).
 
-            # Construct the bin transform
-            # TODO: Might be a faster way of doing this...
-            # TODO: Set this to be a scipy.sparse.csr_matrix?
-            self.bin_transform = np.array([(binid_map == b).astype(float) 
-                                            for b in self.binid])/nbin.astype(float)[:,None]
+            # Construct the bin transform using a sparse matrix
+            d,i,j = np.array([[1/nbin[i],i,j] 
+                             for i,b in enumerate(self.binid)
+                             for j in np.where(binid_map == b)[0]]).T
+            self.bin_transform = sparse.coo_matrix((d,(i.astype(int),j.astype(int))),
+                                                   shape=(self.binid.size,
+                                                          np.prod(self.spatial_shape))).tocsr()
 
         # Unravel and select the valid values for all arrays
         for attr in ['x', 'y', 'sb', 'sb_ivar', 'sb_mask', 'vel', 'vel_ivar', 'vel_mask', 'sig', 
                      'sig_ivar', 'sig_mask']:
             if getattr(self, attr) is not None:
                 setattr(self, attr, getattr(self, attr).ravel()[indx])
+
+    def _set_beam(self, psf, aperture):
+        """
+        Construct the beam and beam FFT based on the input. If no psf
+        or aperture are provided, both are set to None.
+        """
+        if psf is None and aperture is None:
+            self.beam = None
+            self.beam_fft = None
+            return
+        if psf is None:
+            self.beam = aperture
+            self.beam_fft = np.fft.fftn(np.fft.ifftshift(aperture))
+            return
+        if aperture is None:
+            self.beam = psf
+            self.beam_fft = np.fft.fftn(np.fft.ifftshift(psf))
+            return
+        self.beam_fft = construct_beam(psf, aperture, return_fft=True)
+        self.beam = np.fft.ifftn(self.beam_fft).real
 
     def _ingest(self, data, ivar, mask):
         """
@@ -263,7 +286,7 @@ class Kinematics(FitArgs):
 
         # Set the error and incorporate the mask for a masked array
         if ivar is None:
-            _ivar = np.ones(self.spatial_shape, dtype=float)
+            _ivar = None #np.ones(self.spatial_shape, dtype=float)
         elif isinstance(ivar, np.ma.MaskedArray):
             _mask |= np.ma.getmaskarray(ivar)
             _ivar = ivar.data
@@ -273,6 +296,13 @@ class Kinematics(FitArgs):
         _mask |= np.logical_not(_ivar > 0)
 
         return _data, _ivar, _mask
+
+    def remap_data(self, data):
+        if data.shape != self.vel.shape:
+            raise ValueError('To remap, must have the same shape as the internal data attributes.')
+        _data = np.zeros(self.spatial_shape, dtype=float)
+        _data[np.unravel_index(self.grid_indx, self.spatial_shape)] = data[self.bin_inverse]
+        return _data
 
     # TODO: include sigma correction when attr='sig'?
     def remap(self, attr, masked=True, new_attr=True):
@@ -335,8 +365,9 @@ class Kinematics(FitArgs):
             ValueError:
                 Raised if the shape of the input array is incorrect.
         """
+        # TODO: Speed this up.
         if data.shape != self.spatial_shape:
             raise ValueError('Data to rebin has incorrect shape; expected {0}, found {1}.'.format(
                               self.spatial_shape, data.shape))
-        return np.dot(self.bin_transform, data.ravel())
+        return self.bin_transform.dot(data.ravel())
 

--- a/barfit/data/manga.py
+++ b/barfit/data/manga.py
@@ -265,7 +265,7 @@ class MaNGAStellarKinematics(MaNGAKinematics):
         psf_ext (:obj:`str`, optional):
             The name of the extension with the reconstructed PSF.
     """
-    def __init__(self, maps_file, cube_file, psf_ext='GPSF'):
+    def __init__(self, maps_file, cube_file=None, psf_ext='GPSF'):
 
         if not os.path.isfile(maps_file):
             raise FileNotFoundError('File does not exist: {0}'.format(maps_file))

--- a/barfit/models/axisym.py
+++ b/barfit/models/axisym.py
@@ -175,5 +175,3 @@ class AxisymmetricDisk:
         self.par_err = np.zeros(self.np, dtype=float)
         self.par_err[self.free] = np.sqrt(np.diag(cov))
 
-
-        

--- a/barfit/models/axisym.py
+++ b/barfit/models/axisym.py
@@ -1,0 +1,159 @@
+
+from IPython import embed
+
+import numpy as np
+
+from scipy import optimize
+
+from .oned import HyperbolicTangent
+from .geometry import projected_polar
+from .beam import smear
+from .util import cov_err
+
+class AxisymmetricDisk:
+    """
+    Simple model for an axisymmetric disk.
+
+    Base parameters are xc, yc, pa, inc, vsys.
+
+    Full parameters include number of *projected* rotation curve
+    parameters.
+    """
+    def __init__(self, rc=None):
+        # Rotation curve
+        self.rc = HyperbolicTangent() if rc is None else rc
+
+        # Number of "base" parameters
+        self.nbp = 5
+        # Total number parameters
+        self.np = self.nbp + self.rc.np
+        # Initialize the parameters
+        self.par = self.guess_par()
+        self.par_err = None
+        # Flag which parameters are freely fit
+        self.free = np.ones(self.np, dtype=bool)
+        self.nfree = np.sum(self.free)
+
+        # Workspace
+        self.x = None
+        self.y = None
+        self.beam_fft = None
+        self.kin = None
+
+    def guess_par(self):
+        return np.concatenate(([0., 0., 45., 30., 0.], self.rc.guess_par()))
+
+    def base_par(self):
+        """
+        Return the base parameters.  Returns None if parameters are not defined yet.
+        """
+        return None if self.par is None else self.par[:self.nbp]
+
+    def par_bounds(self):
+        minx = np.amin(self.x)
+        maxx = np.amax(self.x)
+        miny = np.amin(self.y)
+        maxy = np.amax(self.y)
+        maxr = np.sqrt(max(abs(minx), maxx)**2 + max(abs(miny), maxy)**2)
+        rclb, rcub = self.rc.par_bounds(maxr)
+        # Minimum and maximum allowed values for xc, yc, pa, inc, vsys, vrot, hrot
+        return np.concatenate(([minx, miny, -350., 0., -300.], rclb)), \
+               np.concatenate(([maxx, maxy, 350., 89., 300.], rcub))
+
+    def _set_par(self, par):
+        """
+        Set the parameters by accounting for any fixed parameters.
+        """
+        if par.ndim != 1:
+            raise ValueError('Parameter array must be a 1D vector.')
+        if par.size == self.np:
+            self.par = par.copy()
+            return
+        if par.size != self.nfree:
+            raise ValueError('Must provide {0} or {1} parameters.'.format(self.np, self.nfree))
+        self.par[self.free] = par.copy()
+
+    def _init_coo(self, x, y, beam, is_fft):
+        if x is not None:
+            self.x = x
+        if y is not None:
+            self.y = y
+        if beam is not None:
+            self.beam_fft = beam if is_fft else np.fft.fftn(np.fft.ifftshift(beam))
+
+        if self.x.shape != self.y.shape:
+            raise ValueError('Input coordinates must have the same shape.')
+        if self.beam_fft is not None:
+            if self.x.ndim != 2:
+                raise ValueError('To perform convolution, must provide 2d coordinate arrays.')
+            if self.beam_fft.shape != self.x.shape:
+                raise ValueError('Currently, convolution requires the beam map to have the same '
+                                 'shape as the coordinate maps.')
+
+    def _init_par(self, p0, fix):
+        if p0 is None:
+            p0 = self.guess_par()
+        _p0 = np.atleast_1d(p0)
+        if _p0.size != self.np:
+            raise ValueError('Incorrect number of model parameters.')
+        self.par = _p0
+        self.par_err = None
+        _free = np.ones(self.np, dtype=bool) if fix is None else np.logical_not(fix)
+        if _free.size != self.np:
+            raise ValueError('Incorrect number of model parameter fitting flags.')
+        self.free = _free
+        self.nfree = np.sum(self.free)
+
+    def model(self, par=None, x=None, y=None, beam=None, is_fft=False):
+        """
+        Evaluate the model.
+        """
+        if x is not None or y is not None or beam is not None:
+            self._init_coo(x, y, beam, is_fft)
+        if self.x is None or self.y is None:
+            raise ValueError('No coordinate grid defined.')
+        if par is not None:
+            self._set_par(par)
+
+        r, theta = projected_polar(self.x - self.par[0], self.y - self.par[1],
+                                   *np.radians(self.par[2:4]))
+
+        # NOTE: This doesn't include the sin(inclination) term because
+        # this is absorbed into the rotation curve amplitude.
+        vel = self.rc.sample(r, par=self.par[self.nbp:])*np.cos(theta) + self.par[4]
+        return vel if self.beam_fft is None else smear(vel, self.beam_fft, beam_fft=True)[1]
+
+    def _resid(self, par):
+        self._set_par(par)
+        return self.kin.vel[self.vel_gpm] - self.kin.bin(self.model())[self.vel_gpm]
+
+    def _chisqr(self, par): 
+        return self._resid(par) * np.sqrt(self.kin.vel_ivar[self.vel_gpm])
+
+    def _fit_prep(self, kin, p0, fix):
+        self._init_par(p0, fix)
+        self.kin = kin
+        self.x = self.kin.grid_x
+        self.y = self.kin.grid_y
+        self.beam_fft = self.kin.beam_fft
+        self.vel_gpm = np.logical_not(self.kin.vel_mask)
+        return self._resid if self.kin.vel_ivar is None else self._chisqr
+
+    def lsq_fit(self, kin, p0=None, fix=None, verbose=0):
+        """
+        Use least_squares to fit kinematics.
+        """
+        fom = self._fit_prep(kin, p0, fix)
+        lb, ub = self.par_bounds()
+        diff_step = np.full(self.np, 0.1, dtype=float)
+        result = optimize.least_squares(fom, self.par[self.free], method='trf',
+                                        bounds=(lb[self.free], ub[self.free]), 
+                                        diff_step=diff_step[self.free], verbose=verbose)
+        self._set_par(result.x)
+
+        cov = cov_err(result.jac)
+        self.par_err = np.zeros(self.np, dtype=float)
+        self.par_err[self.free] = np.sqrt(np.diag(cov))
+
+
+        

--- a/barfit/models/axisym.py
+++ b/barfit/models/axisym.py
@@ -10,6 +10,23 @@ from .geometry import projected_polar
 from .beam import smear
 from .util import cov_err
 
+
+def rotcurveeval(x,y,vmax,inc,pa,h,vsys=0,xc=0,yc=0,reff=1):
+    '''
+    Evaluate a simple tanh rotation curve with asymtote vmax, inclination inc
+    in degrees, position angle pa in degrees, rotation scale h, systematic
+    velocity vsys, and x and y offsets xc and yc. Returns array in same shape
+    as input x andy.
+    '''
+
+    inc, pa = np.radians([inc,pa])
+    r,th = projected_polar(x-xc,y-yc, pa, inc)
+    r /= reff
+    # TODO: Why was there a negative here? (it used to be `-vmax`)
+    model = vmax * np.tanh(r/h) * np.cos(th) * np.sin(inc) + vsys
+    return model
+
+
 class AxisymmetricDisk:
     """
     Simple model for an axisymmetric disk.

--- a/barfit/models/axisym.py
+++ b/barfit/models/axisym.py
@@ -19,11 +19,14 @@ def rotcurveeval(x,y,vmax,inc,pa,h,vsys=0,xc=0,yc=0,reff=1):
     as input x andy.
     '''
 
-    inc, pa = np.radians([inc,pa])
-    r,th = projected_polar(x-xc,y-yc, pa, inc)
+    _inc, _pa = np.radians([inc,pa])
+    r,th = projected_polar(x-xc, y-yc, _pa, _inc)
     r /= reff
-    # TODO: Why was there a negative here? (it used to be `-vmax`)
-    model = vmax * np.tanh(r/h) * np.cos(th) * np.sin(inc) + vsys
+
+    # TODO: Why is there a negative here (i.e., -vmax)? ... After
+    # playing around, I assume this is here because it worked for
+    # 8078-12703 because it flips the PA to be ~180 instead of near 0?
+    model = -vmax * np.tanh(r/h) * np.cos(th) * np.sin(_inc) + vsys
     return model
 
 

--- a/barfit/models/beam.py
+++ b/barfit/models/beam.py
@@ -1,8 +1,134 @@
+"""
+
+.. include:: ../include/links.rst
+"""
+
+from IPython import embed
 
 import numpy as np
-import scipy.signal
 
-def apply_beam_smearing(v, psf, sb=None, sig=None, aperture=None, mask=None, fftw=False):
+
+def gauss2d_kernel(n, sigma):
+    """
+    Return a circular 2D Gaussian.
+
+    Shape of the returned map is nxn, and the sigma is provided in pixels.
+    """
+    x, y = np.meshgrid(*(np.arange(n, dtype=float) - n//2,)*2)
+    d = 2*sigma**2
+    g = np.exp(-(x**2 + y**2) / d) / d / np.pi
+    return g / np.sum(g)
+
+
+def convolve_fft(data, kernel, kernel_fft=False, return_fft=False):
+    """
+    Convolve data with a kernel.
+
+    This is inspired by astropy.convolution.convolve_fft, but
+    stripped down to what's needed for the expected application. That
+    has the benefit of cutting down on the execution time, but limits
+    its use.
+
+    Beware:
+        - ``data`` and ``kernel`` must have the same shape.
+        - Kernel is assumed to sum to unity.
+        - Padding is never added by default.
+
+    """
+    if data.shape != kernel.shape:
+        raise ValueError('Data and kernel must have the same shape.')
+    if not np.all(np.isfinite(data)) or not np.all(np.isfinite(kernel)):
+        raise ValueError('Data and kernel must both have valid values.')
+
+    datafft = np.fft.fftn(data)
+    kernfft = kernel if kernel_fft else np.fft.fftn(np.fft.ifftshift(kernel))
+    fftmult = datafft * kernfft
+
+    return fftmult if return_fft else np.fft.ifftn(fftmult).real
+
+
+def construct_beam(psf, aperture=None, return_fft=False):
+    """
+    Construct the beam profile.
+
+    psf and aperture must have the same shape.
+    psf and aperture are both expected to sum to 1.
+    """
+    return convolve_fft(psf, aperture, return_fft=return_fft)
+
+
+def smear(v, beam, beam_fft=False, sb=None, sig=None):
+    """
+    Get the beam-smeared surface brightness, velocity, and velocity
+    dispersion fields.
+    
+    Args:
+        v (`numpy.ndarray`_):
+            2D array with the discretely sampled velocity field. Must
+            be square.
+        beam (`numpy.ndarray`_):
+            An image of the beam profile or its precomputed FFT. Must
+            be the same shape as ``v``. If the beam profile is
+            provided, it is expected to be normalized to unity.
+        beam_fft (:obj:`bool`, optional):
+            Flag that the provided data for ``beam`` is actually the
+            precomputed FFT of the beam profile.
+        sb (`numpy.ndarray`_, optional):
+            2D array with the surface brightness of the object. This
+            is used to weight the convolution of the kinematic fields
+            according to the luminosity distribution of the object.
+            Must have the same shape as ``v``. If None, the
+            convolution is unweighted.
+        sig (`numpy.ndarray`_, optional):
+            2D array with the velocity dispersion measurements. Must
+            have the same shape as ``v``.
+
+    Returns:
+        :obj:`tuple`: Tuple of three objects, which are nominally the
+        beam-smeared surface brightness, velocity, and velocity
+        dispersion fields. The first and last objects in the tuple
+        can be None, if ``sb`` or ``sig`` are not provided,
+        respectively. The 2nd returned object is always the
+        beam-smeared velocity field.
+
+    Raises:
+        ValueError:
+            Raised if the provided arrays are not 2D or if the shapes
+            of the arrays are not all the same.
+    """
+    if v.ndim != 2:
+        raise ValueError('Can only accept 2D images.')
+    if beam.shape != v.shape:
+        raise ValueError('Input beam and velocity field array sizes must match.')
+    if sb is not None and sb.shape != v.shape:
+        raise ValueError('Input surface-brightness and velocity field array sizes must match.')
+    if sig is not None and sig.shape != v.shape:
+        raise ValueError('Input velocity dispersion and velocity field array sizes must match.')
+
+    # Pre-compute the beam FFT
+    bfft = beam if beam_fft else np.fft.fftn(np.fft.ifftshift(beam))
+
+    # Get the first moment of the beam-smeared intensity distribution
+    mom0 = None if sb is None else convolve_fft(sb, bfft, kernel_fft=True)
+
+    # First moment
+    mom1 = convolve_fft(v if sb is None else sb*v, bfft, kernel_fft=True)
+    if mom0 is not None:
+        mom1 /= (mom0 + (mom0 == 0.0))
+
+    if sig is None:
+        # Sigma not provided so we're done
+        return mom0, mom1, None
+
+    # Second moment
+    _sig = np.square(v) + np.square(sig)
+    mom2 = convolve_fft(_sig if sb is None else sb*_sig, bfft, kernel_fft=True)
+    mom2 = mom2 / (mom0 + (mom0 == 0.0)) - mom1**2
+    mom2[mom2 < 0] = 0.0
+    return mom0, mom1, np.sqrt(mom2)
+
+
+def apply_beam_smearing_old(v, psf, sb=None, sig=None, aperture=None, mask=None, fftw=False):
     """
     Get the beam-smeared surface brightness, velocity, and velocity
     dispersion fields.

--- a/barfit/models/beam.py
+++ b/barfit/models/beam.py
@@ -47,7 +47,7 @@ def convolve_fft(data, kernel, kernel_fft=False, return_fft=False):
     return fftmult if return_fft else np.fft.ifftn(fftmult).real
 
 
-def construct_beam(psf, aperture=None, return_fft=False):
+def construct_beam(psf, aperture, return_fft=False):
     """
     Construct the beam profile.
 

--- a/barfit/models/geometry.py
+++ b/barfit/models/geometry.py
@@ -1,0 +1,76 @@
+"""
+Methods for geometric projection.
+"""
+
+import numpy as np
+
+def rotate(x, y, rot, clockwise=False):
+    r"""
+    Rotate a set of coordinates about :math:`(x,y) = (0,0)`.
+
+    Args:
+        x (array-like):
+            Cartesian x coordinates.
+        y (array-like):
+            Cartesian y coordinates.
+        rot (:obj:`float`):
+            Rotation angle in radians.
+        clockwise (:obj:`bool`, optional):
+            Perform a clockwise rotation. Rotation is
+            counter-clockwise by default.
+
+    Returns:
+        :obj:`tuple`: Two `numpy.ndarray`_ objects with the rotated x
+        and y coordinates.
+    """
+    cosr = np.cos(rot)
+    sinr = np.sin(rot)
+    _x = np.asarray(x)
+    _y = np.asarray(y)
+    if clockwise:
+        return _x*cosr + _y*sinr, _y*cosr - _x*sinr
+    return _x*cosr - _y*sinr, _y*cosr + _x*sinr
+
+
+def projected_polar(x, y, pa, inc):
+    r"""
+    Calculate the in-plane polar coordinates of an inclined plane.
+
+    The position angle, :math:`\phi_0`, is the rotation from the
+    :math:`y=0` axis through the :math:`x=0` axis. I.e.,
+    :math:`\phi_0 = \pi/2` is along the :math:`+x` axis and
+    :math:`\phi_0 = \pi` is along the :math:`-y` axis.
+
+    The inclination, :math:`i`, is the angle of the plane normal with
+    respect to the line-of-sight. I.e., :math:`i=0` is a face-on
+    (top-down) view of the plane and :math:`i=\pi/2` is an edge-on
+    view.
+
+    The returned coordinates are the projected distance from the
+    :math:`(x,y) = (0,0)` and the project azimuth. The projected
+    azimuth, :math:`\theta`, is defined to increase in the same
+    direction as :math:`\phi_0`, with :math:`\theta = 0` at
+    :math:`\phi_0`.
+
+    Args:
+        x (array-like):
+            Cartesian x coordinates.
+        y (array-like):
+            Cartesian y coordinates.
+        pa (:obj:`float`)
+            Position angle, as defined above, in radians.
+        inc (:obj:`float`)
+            Inclination, as defined above, in radians.
+
+    Returns:
+        :obj:`tuple`: Returns two arrays with the projected radius
+        and in-plane azimuth. The radius units are identical to the
+        provided cartesian coordinates. The azimuth is in radians
+        over the range :math:`[0,2\pi]`.
+    """
+    xd, yd = rotate(x, y, np.pi/2-pa, clockwise=True)
+    yd /= np.cos(inc)
+    # Absolute is to deal with annoying "-0." cases.
+    return np.sqrt(xd**2 + yd**2), np.arctan2(-yd,xd) % (2*np.pi)
+
+

--- a/barfit/models/geometry.py
+++ b/barfit/models/geometry.py
@@ -70,7 +70,6 @@ def projected_polar(x, y, pa, inc):
     """
     xd, yd = rotate(x, y, np.pi/2-pa, clockwise=True)
     yd /= np.cos(inc)
-    # Absolute is to deal with annoying "-0." cases.
     return np.sqrt(xd**2 + yd**2), np.arctan2(-yd,xd) % (2*np.pi)
 
 

--- a/barfit/models/oned.py
+++ b/barfit/models/oned.py
@@ -1,0 +1,178 @@
+"""
+Implements one-dimensional functions for modeling.
+"""
+import warnings
+
+from IPython import embed
+
+import numpy as np
+from .util import lin_interp
+
+
+class StepFunction:
+    def __init__(self, edges, par=None):
+        self.edges = np.sort(edges)
+        if not np.array_equal(self.edges, edges):
+            warnings.warn('As provided, edges for PiecewiseLinear were not sorted.')
+        self.np = self.edges.size
+        self.par = np.ones(self.np, dtype=float)
+        self._set_par(par)
+
+    def __call__(self, r, par=None):
+        return self.sample(r, par=par)
+
+    def _set_par(self, par):
+        if par is not None:
+            if len(par) != self.np:
+                raise ValueError('Incorrect number of parameters.')
+            self.par = np.atleast_1d(par)
+
+    def _sort(self, r, check):
+        i2 = np.searchsorted(self.edges, r, side='right')
+        if not check:
+            return i2
+        if not np.all(np.isin(np.arange(self.np-1)+1, np.unique(i2))):
+            raise ValueError('Not all segments of the piece-wise linear function are constrained.')
+
+    def sample(self, r, par=None, check=False):
+        if par is not None:
+            self._set_par(par)
+        f = np.full(r.size, self.edges[0], dtype=float)
+        i2 = self._sort(r, check)
+        indx = (i2 > 0)
+        f[indx] = self.par[i2[indx]-1]
+        return f
+
+    def ddr(self, r, par=None):
+        return np.zeros(r.size, dtype=float)
+
+    def d2dr2(self, x, par=None):
+        return np.zeros(r.size, dtype=float)
+
+
+class PiecewiseLinear:
+    def __init__(self, edges, par=None):
+        self.edges = np.sort(edges)
+        if not np.array_equal(self.edges, edges):
+            warnings.warn('As provided, edges for PiecewiseLinear were not sorted.')
+        self.np = self.edges.size
+        self.par = np.ones(self.np, dtype=float)
+        self._set_par(par)
+
+    def __call__(self, r, par=None):
+        return self.sample(r, par=par)
+
+    def _set_par(self, par):
+        if par is not None:
+            if len(par) != self.np:
+                raise ValueError('Incorrect number of parameters.')
+            self.par = np.atleast_1d(par)
+
+    def _sort(self, r, check):
+        i2 = np.searchsorted(self.edges, r, side='right')
+        if not check:
+            return i2
+        if not np.all(np.isin(np.arange(self.np-1)+1, np.unique(i2))):
+            raise ValueError('Not all segments of the piece-wise linear function are constrained.')
+
+    def sample(self, r, par=None, check=False):
+        if par is not None:
+            self._set_par(par)
+        f = np.full(r.size, self.edges[0], dtype=float)
+        i2 = self._sort(r, check)
+        indx = (i2 > 0) & (i2 < self.np)
+        f[indx] = lin_interp(r[indx], self.edges[i2[indx]-1], self.par[i2[indx]-1],
+                             self.edges[i2[indx]], self.par[i2[indx]])
+        f[i2 == self.np] = self.par[-1]
+        return f
+
+    def ddr(self, r, par=None):
+        if par is not None:
+            self._set_par(par)
+        f = np.zeros(r.size, dtype=float)
+        i2 = self._sort(r, check)
+        indx = (i2 > 0) & (i2 < self.np)
+        f[indx] = (self.par[i2[indx]] - self.par[i2[indx]-1]) \
+                    / (self.edges[i2[indx]] - self.edges[i2[indx]-1])
+        return f
+
+    def d2dr2(self, x, par=None):
+        return np.zeros(r.size, dtype=float)
+
+
+class HyperbolicTangent:
+    """
+    Instantiates a hyperbolic tangent function.
+    """
+    def __init__(self, par=None):
+        self.np = 2
+        self.par = self.guess_par()
+        self._set_par(par)
+
+    def __call__(self, r, par=None):
+        return self.sample(r, par=par)
+        
+    def _set_par(self, par):
+        if par is not None:
+            if len(par) != self.np:
+                raise ValueError('Incorrect number of parameters.')
+            self.par = np.atleast_1d(par)
+
+    @staticmethod
+    def guess_par():
+        return np.array([100., 10.])
+
+    @staticmethod
+    def par_bounds(maxr):
+        return np.array([0., 1e-3]), np.array([500., maxr])
+
+    def sample(self, r, par=None):
+        if par is not None:
+            self._set_par(par)
+        return self.par[0]*np.tanh(r/self.par[1])
+
+    def ddr(self, r, par=None):
+        if par is not None:
+            self._set_par(par)
+        sech2 = (1./numpy.cosh(r/self.par[1]))**2
+        return self.par[0] * sech2 / self.par[1]
+
+    def d2dr2(self, r, par=None):
+        if par is not None:
+            self._set_par(par)
+        rh = r/self.hrot
+        sech2 = (1./numpy.cosh(rh))**2
+        tanh = np.tanh(rh)
+        return -2. * self.par[0] * sech2 * tanhr / self.par[1]**2 
+
+
+class Exponential:
+    """
+    Exponential profile.
+    """
+    def __init__(self, par=None):
+        self.np = 2
+        self.par = np.ones(self.np, dtype=float)
+        self._set_par(par)
+
+    def __call__(self, r, par=None):
+        return self.sample(r, par=par)
+        
+    def _set_par(self, par):
+        if par is not None:
+            if len(par) != self.np:
+                raise ValueError('Incorrect number of parameters.')
+            self.par = np.atleast_1d(par)
+
+    def sample(self, r, par=None):
+        if par is not None:
+            self._set_par(par)
+        return self.par[0]*np.exp(-r/self.par[1])
+
+    def ddr(self, r, par=None):
+        if par is not None:
+            self._set_par(par)
+        return -self.sample(r)/self.par[1]
+
+
+

--- a/barfit/models/util.py
+++ b/barfit/models/util.py
@@ -1,0 +1,32 @@
+
+"""
+Utility function for modeling.
+"""
+
+import numpy as np
+from scipy import linalg
+
+def cov_err(jac):
+    """
+    Pulled from ppxf.capfit.cov_err, but only returns the covariance matrix.
+
+    Covariance and 1sigma formal errors calculation (i.e. ignoring covariance).
+    See e.g. Press et al. 2007, Numerical Recipes, 3rd ed., Section 15.4.2
+    """
+    U, s, Vh = linalg.svd(jac, full_matrices=False)
+    w = s > np.spacing(s[0])*max(jac.shape)
+    return (Vh[w].T/s[w]**2) @ Vh[w]
+
+
+def lin_interp(x, x1, y1, x2, y2):
+    """
+    Linearly interpolate a new value at position x given two points
+    that define the line.
+
+    .. warning::
+
+        Will raise runtime warnings if ``np.any(x1 == x2)`` due to a
+        division by 0, but this not checked.
+
+    """
+    return y1 + (y2-y1) * (x-x1) / (x2-x1)

--- a/barfit/scripts/barfit.py
+++ b/barfit/scripts/barfit.py
@@ -13,6 +13,14 @@ def parse_args(options=None):
 
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('plateifu', nargs=2, type=int, help='MaNGA plate and ifu identifiers')
+    parser.add_argument('-d', '--daptype', default='HYB10-MILESHC-MASTARHC', type=str,
+                        help='DAP analysis key used to select the data files.  This is needed '
+                             'regardless of whether or not you specify the directory with the '
+                             'data files (using --root).')
+    parser.add_argument('--dr', default='MPL-9', type=str,
+                        help='The MaNGA data release.  This is only used to automatically '
+                             'construct the directory to the MaNGA galaxy data, and it will be '
+                             'ignored if the root directory is set directly (using --root).')
     parser.add_argument('-c', '--cores', default=20, type=int,
                         help='Number of threads to utilize.')
     parser.add_argument('-f', '--outfile', default=None, type=str,
@@ -25,16 +33,22 @@ def parse_args(options=None):
                         help='Maximum radius in Re for bins')
     parser.add_argument('-p', '--points', default = 500, type=int,
                         help='Number of dynesty live points')
-    parser.add_argument('--nosmear', action='store_true', default=False,
+    parser.add_argument('--root', default=None, type=str,
+                        help='Path with the fits files required for the fit; the DAP LOGCUBE '
+                             'file is only required if the beam-smearing is included in the fit.')
+    parser.add_argument('--nosmear', dest='smearing', default=True, action='store_false',
                         help='Don\'t use beam smearing to speed up fit')
+    parser.add_argument('--verbose', default=False, action='store_true',
+                        help='Run dynesty sampling with verbose output.')
 
     return parser.parse_args() if options is None else parser.parse_args(options)
 
 def main(args):
 
     plate, ifu = args.plateifu
-    samp = barfit(plate, ifu, cores=args.cores, nbins=args.nbins, weight=args.weight,
-                  maxr=args.maxr, smearing=~args.nosmear)
+    samp = barfit(plate, ifu, daptype=args.daptype, dr=args.dr, cores=args.cores, nbins=args.nbins,
+                  weight=args.weight, maxr=args.maxr, smearing=args.smearing, root=args.root,
+                  verbose=args.verbose)
     if args.outfile is None:
         args.outfile = f'{plate}-{ifu}_{args.nbins}.out'
     # TODO: Do we need to use pickle?

--- a/barfit/tests/lsq.py
+++ b/barfit/tests/lsq.py
@@ -1,0 +1,34 @@
+
+from IPython import embed
+
+import numpy
+
+from barfit.data import manga
+from barfit.tests.util import remote_data_file
+from barfit.models.oned import HyperbolicTangent
+from barfit.models.axisym import AxisymmetricDisk
+
+# Benchmarking test for the least-squares fit
+def test_lsq_nopsf():
+
+    # Read the data to fit
+    data_root = remote_data_file()
+    kin = manga.MaNGAGasKinematics.from_plateifu(8078, 12703, cube_path=data_root,
+                                                 maps_path=data_root)
+
+    nrun = 100
+    for i in range(nrun):
+        print('{0}/{1}'.format(i+1,nrun), end='\r')
+        # Set the rotation curve
+        rc = HyperbolicTangent()
+        # Set the disk velocity field
+        disk = AxisymmetricDisk(rc)
+        # Fit it with a non-linear least-squares optimizer
+        disk.lsq_fit(kin)
+    print('{0}/{0}'.format(nrun))
+
+if __name__ == '__main__':
+    test_lsq_nopsf()
+
+
+

--- a/barfit/tests/test_axisym.py
+++ b/barfit/tests/test_axisym.py
@@ -1,0 +1,71 @@
+
+from IPython import embed
+
+import numpy
+
+from barfit.data import manga
+from barfit.tests.util import remote_data_file, requires_remote, dap_test_daptype
+from barfit.models.oned import HyperbolicTangent
+from barfit.models.axisym import AxisymmetricDisk
+from barfit.models.beam import convolve_fft, smear, gauss2d_kernel
+
+def test_disk():
+    disk = AxisymmetricDisk()
+    disk.par[:2] = 0.       # Ensure that the center is at 0,0
+    disk.par[-1] = 1.       # Put in a quickly rising RC
+
+    n = 51
+    x = numpy.arange(n, dtype=float)[::-1] - n//2
+    y = numpy.arange(n, dtype=float) - n//2
+    x, y = numpy.meshgrid(x, y)
+
+    vel = disk.model(disk.par, x=x, y=y)
+    beam = gauss2d_kernel(n, 3.)
+    _vel = disk.model(disk.par, x=x, y=y, beam=beam)
+
+    assert numpy.isclose(vel[n//2,n//2], _vel[n//2,n//2]), 'Smearing moved the center.'
+
+@requires_remote
+def test_lsq_nopsf():
+
+    # Read the data to fit
+    data_root = remote_data_file()
+    kin = manga.MaNGAGasKinematics.from_plateifu(8138, 12704, cube_path=data_root,
+                                                 maps_path=data_root, ignore_psf=True)
+    # Set the rotation curve
+    rc = HyperbolicTangent()
+    # Set the disk velocity field
+    disk = AxisymmetricDisk(rc)
+    # Fit it with a non-linear least-squares optimizer
+    disk.lsq_fit(kin)
+
+    assert numpy.all(numpy.absolute(disk.par[:2]) < 0.1), 'Center changed'
+    assert 165. < disk.par[2] < 167., 'PA changed'
+    assert 53. < disk.par[3] < 54., 'Inclination changed'
+    assert 242. < disk.par[5] < 244., 'Projected rotation changed'
+
+
+@requires_remote
+def test_lsq_psf():
+
+    # Read the data to fit
+    data_root = remote_data_file()
+    kin = manga.MaNGAGasKinematics.from_plateifu(8138, 12704, cube_path=data_root,
+                                                 maps_path=data_root)
+    # Set the rotation curve
+    rc = HyperbolicTangent()
+    # Set the disk velocity field
+    disk = AxisymmetricDisk(rc)
+    # Fit it with a non-linear least-squares optimizer
+    disk.lsq_fit(kin)
+
+    assert numpy.all(numpy.absolute(disk.par[:2]) < 0.1), 'Center changed'
+    assert 165. < disk.par[2] < 167., 'PA changed'
+    assert 56. < disk.par[3] < 57., 'Inclination changed'
+    assert 250. < disk.par[5] < 252., 'Projected rotation changed'
+
+if __name__ == '__main__':
+    test_lsq_nopsf()
+
+
+

--- a/barfit/tests/test_axisym.py
+++ b/barfit/tests/test_axisym.py
@@ -64,8 +64,5 @@ def test_lsq_psf():
     assert 56. < disk.par[3] < 57., 'Inclination changed'
     assert 250. < disk.par[5] < 252., 'Projected rotation changed'
 
-if __name__ == '__main__':
-    test_lsq_nopsf()
-
 
 

--- a/barfit/tests/test_beam.py
+++ b/barfit/tests/test_beam.py
@@ -1,0 +1,42 @@
+
+from IPython import embed
+
+import numpy
+
+from astropy import convolution
+
+from barfit.models.beam import convolve_fft, gauss2d_kernel
+
+def test_convolve():
+    """
+    Test that the results of the convolution match astropy.
+    """
+    synth = gauss2d_kernel(73, 3.)
+    astsynth = convolution.convolve_fft(synth, synth, fft_pad=False, psf_pad=False,
+                                        boundary='wrap')
+    intsynth = convolve_fft(synth, synth)
+    assert numpy.all(numpy.isclose(astsynth, intsynth)), 'Difference wrt astropy convolution'
+
+
+def test_beam():
+    """
+    Test that the convolution doesn't shift the center (at least when
+    the kernel is constructed with gauss2d_kernel).
+
+    Note this test fails if you use scipy.fftconvolve because the
+    kernels are treated differently.
+    """
+    n = 50
+    beam = gauss2d_kernel(n, 3.)
+    _beam = convolve_fft(beam, beam)
+    assert numpy.argmax(beam) == numpy.argmax(_beam), \
+            'Beam kernel shifted the center for an even image size.'
+
+    n = 51
+    beam = gauss2d_kernel(n, 3.)
+    _beam = convolve_fft(beam, beam)
+    assert numpy.argmax(beam) == numpy.argmax(_beam), \
+            'Beam kernel shifted the center for an odd image size.'
+
+
+

--- a/barfit/tests/test_geometry.py
+++ b/barfit/tests/test_geometry.py
@@ -1,0 +1,32 @@
+"""
+Module for testing the geometry module.
+"""
+
+from IPython import embed
+
+import numpy
+
+from barfit.models.geometry import rotate, projected_polar
+
+def test_polar():
+
+    n = 51
+    x = numpy.arange(n, dtype=float)[::-1] - n//2
+    y = numpy.arange(n, dtype=float) - n//2
+    x, y = numpy.meshgrid(x, y)
+
+    # Parameters are xc, yc, rotation, pa, inclination
+    par = [10., 10., 10., 45., 30.]
+    if par[2] > 0:
+        xf, yf = map(lambda x,y : x - y, rotate(x, y, numpy.radians(par[2]), clockwise=True), par[:2])
+    else:
+        xf, yf = x - par[0], y - par[1]
+
+    r, th = projected_polar(xf, yf, *numpy.radians(par[3:]))
+
+    indx = numpy.unravel_index(numpy.argmin(r), r.shape)
+    assert indx[0] > n//2 and indx[1] < n//2, 'Offset in wrong direction.'
+
+    assert numpy.amax(r) > n/2, 'Inclination should result in larger radius'
+    assert not numpy.any(th < 0) and not numpy.any(th > 2*numpy.pi), 'Theta has wrong range'
+

--- a/barfit/tests/test_manga.py
+++ b/barfit/tests/test_manga.py
@@ -20,12 +20,7 @@ def test_manga_gas_kinematics():
     maps_file = remote_data_file('manga-8138-12704-MAPS-{0}.fits.gz'.format(dap_test_daptype))
     cube_file = remote_data_file('manga-8138-12704-LOGCUBE.fits.gz')
 
-    #kin = manga.MaNGAGasKinematics(maps_file, cube_file)
-    kin = manga.MaNGAStellarKinematics(maps_file)
-
-    embed()
-    exit()
-
+    kin = manga.MaNGAGasKinematics(maps_file, cube_file)
     _vel = kin.remap('vel', masked=False)
 
     with fits.open(maps_file) as hdu:
@@ -65,6 +60,7 @@ def test_from_plateifu():
 
     assert maps_file == _maps_file, 'MAPS file name incorrect'
     assert cube_file == _cube_file, 'CUBE file name incorrect'
+
 
 if __name__ == '__main__':
     test_manga_gas_kinematics()

--- a/barfit/tests/test_manga.py
+++ b/barfit/tests/test_manga.py
@@ -5,8 +5,13 @@ import numpy
 
 from astropy.io import fits
 
+from scipy import signal
+from astropy import convolution
+
 from barfit.data import manga
 from barfit.tests.util import remote_data_file, requires_remote, dap_test_daptype
+
+from barfit.models.beam import convolve_fft, gauss2d_kernel
 
 # TODO: Test remapping
 
@@ -15,7 +20,12 @@ def test_manga_gas_kinematics():
     maps_file = remote_data_file('manga-8138-12704-MAPS-{0}.fits.gz'.format(dap_test_daptype))
     cube_file = remote_data_file('manga-8138-12704-LOGCUBE.fits.gz')
 
-    kin = manga.MaNGAGasKinematics(maps_file, cube_file)
+    #kin = manga.MaNGAGasKinematics(maps_file, cube_file)
+    kin = manga.MaNGAStellarKinematics(maps_file)
+
+    embed()
+    exit()
+
     _vel = kin.remap('vel', masked=False)
 
     with fits.open(maps_file) as hdu:
@@ -55,4 +65,8 @@ def test_from_plateifu():
 
     assert maps_file == _maps_file, 'MAPS file name incorrect'
     assert cube_file == _cube_file, 'CUBE file name incorrect'
+
+if __name__ == '__main__':
+    test_manga_gas_kinematics()
+
 

--- a/barfit/tests/test_manga.py
+++ b/barfit/tests/test_manga.py
@@ -62,7 +62,3 @@ def test_from_plateifu():
     assert cube_file == _cube_file, 'CUBE file name incorrect'
 
 
-if __name__ == '__main__':
-    test_manga_gas_kinematics()
-
-

--- a/barfit/tests/util.py
+++ b/barfit/tests/util.py
@@ -20,10 +20,11 @@ def remote_data_file(filename=None):
     return root if filename is None else os.path.join(root, filename)
 
 def remote_drp_test_files():
-    return ['manga-8138-12704-LOGCUBE.fits.gz']
+    return ['manga-8138-12704-LOGCUBE.fits.gz', 'manga-8078-12703-LOGCUBE.fits.gz']
 
 def remote_dap_test_files(daptype='HYB10-MILESHC-MASTARHC2'):
-    return ['manga-8138-12704-MAPS-{0}.fits.gz'.format(daptype)]
+    return ['manga-8138-12704-MAPS-{0}.fits.gz'.format(daptype),
+            'manga-8078-12703-MAPS-{0}.fits.gz'.format(daptype)]
 
 drp_test_version = 'v3_0_1'
 dap_test_version = '3.0.1'


### PR DESCRIPTION
A big PR that does a number of things.  Let's chat about it before you merge it.

Main things it does:
 - Changes the geometry computation to match my previous approach; see `barfit.models.geometry`
 - Speeds up the beam-smearing convolution some, and checks that the convolution with the MaNGA PSF does not shift the model
 - Dramatically speeds up the `Kinematics.bin` function using `scipy.sparse` matrices.
 - Adds a bunch of test code.
 - Begins the implementation of a general `AxisymmetricDisk` class.  To run the fit on a MaNGA galaxy (modulo the paths):

```
from barfit.data import manga
from barfit.models.axisym import AxisymmetricDisk

kin = manga.MaNGAGasKinematics.from_plateifu(8078, 12703)
disk = AxisymmetricDisk()
disk.lsq_fit(kin)
```

I've propagated the changes to `barfit.barfit`.  But I ran a test and I need help understanding the output.
