### PR TITLE
Adding dispersion fitting to the code

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+0.0.2dev
+--------
+
+ - Added in fitting of dispersion in radial bins
+ - Changed `barfit.barfit.unpack` to use a dictionary
+ - Lots of changes to `barfit.barfit` code to utilize dictionary
+ - Various changes to `FitArgs` and script to accommadate dictionary
+ - Huge changes to `barfit.plotting` for disperion and dictionary
+ - Switched to using `MPL-10` by default
+
 
 0.0.1dev
 --------

--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,8 @@
 - ~~recheck and merge Kyle's code~~
 - ~~test on mock data (no bad points?)~~
 - ~~fix edges of model data (interpolation errors)~~
+- error bars on plots
+- multiple mocks with different characteristics
 - pick out bad points
 - binning schemes
 - add error term
@@ -19,3 +21,5 @@
 - Renaming
     - NASKAR: NonAxiSymmetric Kinematic Analysis Routine
     - NIRVANA: Nonaxisymmetric Irregular Rotational Velocity ANAlysis
+- Jacobians?
+- Fisher matrix?

--- a/barfit/data/fitargs.py
+++ b/barfit/data/fitargs.py
@@ -44,6 +44,13 @@ class FitArgs:
 
         self.fixcent = fixcent
 
+    def setdisp(self, disp):
+        '''
+        Whether or not to fit dispersion.
+        '''
+
+        self.disp = disp
+
     def getguess(self):
         '''
         Generate a set of guess parameters for a given velocity field vf with

--- a/barfit/data/manga.py
+++ b/barfit/data/manga.py
@@ -75,7 +75,7 @@ def read_manga_psf(cube_file, psf_ext):
     return psf
 
 
-def manga_files_from_plateifu(plate, ifu, daptype='HYB10-MILESHC-MASTARHC2', dr='v3_0_1',
+def manga_files_from_plateifu(plate, ifu, daptype='HYB10-MILESHC-MASTARHC2', dr='MPL-10',
                               redux_path=None, cube_path=None, analysis_path=None, maps_path=None):
     """
     Get the DAP maps and DRP datacube files for a given plate and
@@ -199,7 +199,7 @@ class MaNGAKinematics(Kinematics):
     """
 
     @classmethod
-    def from_plateifu(cls, plate, ifu, daptype='HYB10-MILESHC-MASTARHC2', dr='v3_0_1',
+    def from_plateifu(cls, plate, ifu, daptype='HYB10-MILESHC-MASTARHC2', dr='MPL-10',
                       redux_path=None, cube_path=None, analysis_path=None, maps_path=None,
                       ignore_psf=False, **kwargs):
         """

--- a/barfit/plotting.py
+++ b/barfit/plotting.py
@@ -4,12 +4,13 @@ Plotting for barfit results.
 
 import numpy as np
 from matplotlib import pyplot as plt
+import matplotlib
 
 import dynesty
 import corner
 import pickle
 
-from .barfit import barmodel
+from .barfit import barmodel, unpack
 from .data.manga import MaNGAStellarKinematics, MaNGAGasKinematics
 from .data.kinematics import Kinematics
 
@@ -125,7 +126,7 @@ def checkbins(plate,ifu,nbins):
         cut = (er>edges[i])*(er<edges[i+1])
         plt.imshow(np.ma.array(vf, mask=~cut), cmap='RdBu')
 
-def dprofs(samp, edges=False, ax=None, fixcent=False, stds=False, **args):
+def dprofs(samp, args, plot=None, stds=False, **kwargs):
     '''
     Turn a dynesty sampler output by barfit into a set of radial velocity
     profiles. Can plot if edges are given and will plot on a given axis ax if
@@ -135,24 +136,37 @@ def dprofs(samp, edges=False, ax=None, fixcent=False, stds=False, **args):
     #get and unpack median values for params
     meds = dmeds(samp, stds)
     if stds: meds, lstd, ustd = meds
-    inc, pa, pab, vsys = meds[:4]
-    vts  = meds[4::3]
-    v2ts = meds[5::3]
-    v2rs = meds[6::3]
+    paramdict = unpack(meds, args)
+
+    #insert 0 for center bin if necessary
+    if args.fixcent:
+        vts  = np.insert(paramdict['vts'],  0, 0)
+        v2ts = np.insert(paramdict['v2ts'], 0, 0)
+        v2rs = np.insert(paramdict['v2rs'], 0, 0)
+    else:
+        vts  = paramdict['vts']
+        v2ts = paramdict['v2ts']
+        v2rs = paramdict['v2rs']
+
+    #get standard deviations
     if stds:
-        vtl  = lstd[4::3]
-        v2tl = lstd[5::3]
-        v2rl = lstd[6::3]
-        vtu  = ustd[4::3]
-        v2tu = ustd[5::3]
-        v2ru = ustd[6::3]
+        start = args.nglobs
+        jump = len(args.edges)-1
+        if args.fixcent: jump -= 1
+        vtl  = lstd[start:start + jump]
+        v2tl = lstd[start + jump:start + 2*jump]
+        v2rl = lstd[start + 2*jump:start + 3*jump]
+        vtu  = ustd[start:start + jump]
+        v2tu = ustd[start + jump:start + 2*jump]
+        v2ru = ustd[start + 2*jump:start + 3*jump]
+        if args.disp: 
+            if args.fixcent: sigjump = jump+1
+            else: sigjump = jump
+            sigl = lstd[start + 3*jump:start + 3*jump + sigjump]
+            sigu = ustd[start + 3*jump:start + 3*jump + sigjump]
 
-    if fixcent:
-        vts  = np.insert(vts,  0, 0)
-        v2ts = np.insert(v2ts, 0, 0)
-        v2rs = np.insert(v2rs, 0, 0)
-
-        if stds:
+        #add in central bin if necessary
+        if args.fixcent:
             vtl  = np.insert(vtl,  0, 0)
             v2tl = np.insert(v2tl, 0, 0)
             v2rl = np.insert(v2rl, 0, 0)
@@ -160,19 +174,18 @@ def dprofs(samp, edges=False, ax=None, fixcent=False, stds=False, **args):
             v2tu = np.insert(v2tu, 0, 0)
             v2ru = np.insert(v2ru, 0, 0)
 
-
     #plot profiles if edges are given
-    if type(edges) != bool: 
-        if not ax: f,ax = plt.subplots()
+    if plot is not None: 
+        if not isinstance(plot, matplotlib.axes._subplots.Axes): f,plot = plt.subplots()
         ls = [r'$V_t$',r'$V_{2t}$',r'$V_{2r}$']
-        [ax.plot(edges[:-1], p, label=ls[i], **args) for i,p in enumerate([vts,v2ts,v2rs])]
+        [plot.plot(args.edges[:-1], p, label=ls[i], **kwargs) for i,p in enumerate([vts,v2ts,v2rs])]
         if stds: 
-            [ax.fill_between(edges[:-1], p[0], p[1], alpha=.5) for i,p in enumerate([[vtl,vtu],[v2tl,v2tu],[v2rl,v2ru]])]
+            [plot.fill_between(args.edges[:-1], p[0], p[1], alpha=.5) for i,p in enumerate([[vtl,vtu],[v2tl,v2tu],[v2rl,v2ru]])]
         plt.xlabel(r'$R_e$')
         plt.ylabel(r'$v$ (km/s)')
         plt.legend()
 
-    return inc, pa, pab, vsys, vts, v2ts, v2rs
+    return paramdict
 
 def summaryplot(f,nbins,plate,ifu,smearing=True,stellar=False,fixcent=False):
     '''
@@ -186,14 +199,11 @@ def summaryplot(f,nbins,plate,ifu,smearing=True,stellar=False,fixcent=False):
     elif type(f) == np.ndarray: chains = f
     elif type(f) == dynesty.nestedsamplers.MultiEllipsoidSampler: chains = f.results
 
-    resdict = {}
-    resdict['xc'],resdict['yc'] = [0,0]
-    resdict['inc'],resdict['pa'],resdict['pab'],resdict['vsys'],resdict['vts'],resdict['v2ts'],resdict['v2rs'] = dprofs(chains, stds=True)
 
     #mock galaxy using Andrew's values for 8078-12703
     if plate == 0 and ifu == 0 :
         mockparams = dprofs(pickle.load(open('mock.out','rb')))
-        gal = Kinematics.mock(55,*mockparams)
+        gal = Kinematics.mock(55,mockparams['inc'],mockparams['pa'],mockparams['pab'], mockparams['vsys'], mockparams['vts'], mockparams['v2ts'], mockparams['v2rs'])
 
     else:
         if stellar:
@@ -203,37 +213,86 @@ def summaryplot(f,nbins,plate,ifu,smearing=True,stellar=False,fixcent=False):
 
     gal.setedges(nbins,1.5)
     gal.setfixcent(fixcent)
-    gal.setdisp(False)
+    gal.setdisp(True)
+    gal.setnglobs(4)
 
-    model = barmodel(gal,resdict,plot=True)
-    gal.remap('vel')
-    plt.figure(figsize = (8,8))
-    plt.suptitle(f'{plate}-{ifu}')
+    resdict = dprofs(chains, gal, stds=True)
+    velmodel, sigmodel = barmodel(gal,resdict,plot=True)
+
+    [gal.remap(a) for a in ['vel','sig']]
+
+    plt.figure(figsize = (12,12))
+
+    plt.subplot(331)
+    ax = plt.gca()
+    plt.axis('off')
+    plt.title(f'{plate}-{ifu}',size=20)
+    plt.text(.1, .8, r'$i$: %0.1f$^\circ$'%resdict['inc'], 
+            transform=ax.transAxes, size=20)
+    plt.text(.1, .6, r'$\phi$: %0.1f$^\circ$'%resdict['pa'], 
+            transform=ax.transAxes, size=20)
+    plt.text(.1, .4, r'$\phi_b$: %0.1f$^\circ$'%resdict['pab'], 
+            transform=ax.transAxes, size=20)
+    plt.text(.1, .2, r'$v_{{sys}}$: %0.1f km/s'%resdict['vsys'], 
+            transform=ax.transAxes, size=20)
+
+    #Radial velocity profiles
+    plt.subplot(332)
+    dprofs(chains, gal, plt.gca(), stds=True)
+    plt.ylim(bottom=0)
+    plt.title('Velocity Profiles')
+
+    #dispersion profile
+    plt.subplot(333)
+    plt.plot(gal.edges[:-1], resdict['sig'])
+    plt.ylim(bottom=0)
+    plt.title('Velocity Dispersion Profile')
 
     #MaNGA Ha velocity field
-    plt.subplot(221)
-    plt.title(r'H$\alpha$ Data')
+    plt.subplot(334)
+    plt.title(r'H$\alpha$ Velocity Data')
     plt.imshow(gal.vel_r,cmap='jet',origin='lower')
+    plt.tick_params(left=False,bottom=False,labelleft=False,labelbottom=False)
     plt.colorbar(label='km/s')
 
     #VF model from dynesty fit
-    plt.subplot(222)
-    plt.title('Model')
-    plt.imshow(model,'jet',origin='lower',vmin=gal.vel_r.min(),vmax=gal.vel_r.max()) 
+    plt.subplot(335)
+    plt.title('Velocity Model')
+    plt.imshow(velmodel,'jet',origin='lower',vmin=gal.vel_r.min(),vmax=gal.vel_r.max()) 
+    plt.tick_params(left=False,bottom=False,labelleft=False,labelbottom=False)
     plt.colorbar(label='km/s')
 
     #Residuals from fit
-    plt.subplot(223)
-    plt.title('Residuals')
-    resid = gal.vel_r-model
-    vmax = min(np.abs(gal.vel_r-model).max(),50)
-    plt.imshow(gal.vel_r-model,'jet',origin='lower',vmin=-vmax,vmax=vmax)
+    plt.subplot(336)
+    plt.title('Velocity Residuals')
+    resid = gal.vel_r-velmodel
+    vmax = min(np.abs(gal.vel_r-velmodel).max(),50)
+    plt.imshow(gal.vel_r-velmodel,'jet',origin='lower',vmin=-vmax,vmax=vmax)
+    plt.tick_params(left=False,bottom=False,labelleft=False,labelbottom=False)
     plt.colorbar(label='km/s')
 
-    #Radial velocity profiles
-    plt.subplot(224)
-    dprofs(chains, gal.edges, plt.gca(), fixcent, stds=True)
-    plt.ylim(bottom=0)
-    plt.tight_layout()
+    #MaNGA Ha velocity disp
+    plt.subplot(337)
+    plt.title(r'H$\alpha$ Velocity Dispersion Data')
+    plt.imshow(gal.sig_r,cmap='jet',origin='lower')
+    plt.tick_params(left=False,bottom=False,labelleft=False,labelbottom=False)
+    plt.colorbar(label='km/s')
 
-    return dprofs(chains)
+    #disp model from dynesty fit
+    plt.subplot(338)
+    plt.title('Velocity Dispersion Model')
+    plt.imshow(sigmodel,'jet',origin='lower',vmin=gal.sig_r.min(),vmax=gal.sig_r.max()) 
+    plt.tick_params(left=False,bottom=False,labelleft=False,labelbottom=False)
+    plt.colorbar(label='km/s')
+
+    #Residuals from disp fit
+    plt.subplot(339)
+    plt.title('Dispersion Residuals')
+    resid = gal.sig_r-sigmodel
+    vmax = min(np.abs(gal.sig_r-sigmodel).max(),50)
+    plt.imshow(gal.sig_r-sigmodel,'jet',origin='lower',vmin=-vmax,vmax=vmax)
+    plt.tick_params(left=False,bottom=False,labelleft=False,labelbottom=False)
+    plt.colorbar(label='km/s')
+
+    plt.tight_layout()
+    return dprofs(chains, gal)

--- a/barfit/scripts/barfit.py
+++ b/barfit/scripts/barfit.py
@@ -14,11 +14,11 @@ def parse_args(options=None):
 
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('plateifu', nargs=2, type=int, help='MaNGA plate and ifu identifiers')
-    parser.add_argument('-d', '--daptype', default='HYB10-MILESHC-MASTARHC', type=str,
+    parser.add_argument('--daptype', default='HYB10-MILESHC-MASTARHC2', type=str,
                         help='DAP analysis key used to select the data files.  This is needed '
                              'regardless of whether or not you specify the directory with the '
                              'data files (using --root).')
-    parser.add_argument('--dr', default='MPL-9', type=str,
+    parser.add_argument('--dr', default='MPL-10', type=str,
                         help='The MaNGA data release.  This is only used to automatically '
                              'construct the directory to the MaNGA galaxy data, and it will be '
                              'ignored if the root directory is set directly (using --root).')
@@ -45,6 +45,8 @@ def parse_args(options=None):
                         help='Allow center bin to have nonzero velocity.')
     parser.add_argument('--dir', type=str, default = '',
                         help='Directory to save the outfile in')
+    parser.add_argument('--nodisp', dest='disp', default=True, action='store_false',
+                        help='Turn off dispersion fitting')
 
     return parser.parse_args() if options is None else parser.parse_args(options)
 
@@ -57,7 +59,7 @@ def main(args):
     plate, ifu = args.plateifu
     samp = barfit(plate, ifu, daptype=args.daptype, dr=args.dr, cores=args.cores, nbins=args.nbins,
                   weight=args.weight, maxr=args.maxr, smearing=args.smearing, root=args.root,
-                  verbose=args.verbose, fixcent=args.fixcent)
+                  verbose=args.verbose, fixcent=args.fixcent, disp=args.disp)
     if args.outfile is None:
         args.outfile = f'{plate}-{ifu}_{args.nbins}bin_{args.weight}w_{args.points}p'
         if args.smearing: args.outfile += '_s'
@@ -65,6 +67,9 @@ def main(args):
 
         if args.fixcent: args.outfile += '_f'
         else: args.outfile += '_uf'
+
+        if args.disp: args.outfile += '_d'
+        else: args.outfile += '_nd'
     args.outfile += '.out'
 
     # TODO: Do we need to use pickle?


### PR DESCRIPTION
This is the most major update to the core code that has happened in the past few weeks, so I'm upgrading it to version 0.0.2. The two main differences are that the code is now fitting velocity dispersion and that the parameters are organized differently internally.

Dispersion is fit in the same radial binning scheme as the velocity, which adds a fourth parameter per bin. This affects the `barmodel`, `dynprior`, and `llike` functions of `barfit.barfit` the most since they now have to accommodate the new data and parameters. `barfit.plotting.summaryplot` also needed a big rewrite to show dispersion date. **NOTE:** The fit is currently very slow to converge and is not correct (those two things are probably related).

The reorganization of parameters internally is mostly due to the rewriting of the `barfit.barfit` function to use a dictionary instead of a tuple. This should help with practicality and flexibility, but everything else had to be modified to use the new dictionary format, including basically everything in `barfit.barfit` as well as a lot of `plotting`. Hopefully things shouldn't need to be changed again after this since dictionaries can be expanded arbitrarily.

Also, it now defaults to MPL-10.

I'll work on getting the fit to actually be correct over the next few days and then merge it.