### PR TITLE
ConvolveFFTW fixes

### DIFF
--- a/barfit/models/axisym.py
+++ b/barfit/models/axisym.py
@@ -123,7 +123,7 @@ class AxisymmetricDisk:
         self.free = _free
         self.nfree = np.sum(self.free)
 
-    def model(self, par=None, x=None, y=None, beam=None, is_fft=False):
+    def model(self, par=None, x=None, y=None, beam=None, is_fft=False, cnvfftw=None):
         """
         Evaluate the model.
         """
@@ -140,7 +140,8 @@ class AxisymmetricDisk:
         # NOTE: This doesn't include the sin(inclination) term because
         # this is absorbed into the rotation curve amplitude.
         vel = self.rc.sample(r, par=self.par[self.nbp:])*np.cos(theta) + self.par[4]
-        return vel if self.beam_fft is None else smear(vel, self.beam_fft, beam_fft=True)[1]
+        return vel if self.beam_fft is None else smear(vel, self.beam_fft, beam_fft=True,
+                                                       cnvfftw=cnvfftw)[1]
 
     def _resid(self, par):
         self._set_par(par)

--- a/barfit/models/beam.py
+++ b/barfit/models/beam.py
@@ -196,7 +196,7 @@ class ConvolveFFTW:
             return self.data_fft * self.kern_fft
         self.data_fft *= self.kern_fft
         self.ifft()
-        return self.dcnv.real
+        return self.dcnv.real.copy()
 
     def fft(self, data, copy=False):
         """
@@ -317,7 +317,7 @@ def smear(v, beam, beam_fft=False, sb=None, sig=None, cnvfftw=None):
         bfft = beam
     else:
         bfft = np.fft.ifftshift(beam)
-        bfft = np.fft.fftn(bfft) if cnvfftw is None else cnvfftw.fft(bfft)
+        bfft = np.fft.fftn(bfft) if cnvfftw is None else cnvfftw.fft(bfft, copy=True)
 
     # Get the first moment of the beam-smeared intensity distribution
     mom0 = None if sb is None else _cnv(sb, bfft, kernel_fft=True)

--- a/barfit/models/beam.py
+++ b/barfit/models/beam.py
@@ -198,7 +198,7 @@ class ConvolveFFTW:
         self.ifft()
         return self.dcnv.real.copy()
 
-    def fft(self, data, copy=False):
+    def fft(self, data, copy=True, shift=False):
         """
         Calculate the FFT of the provided data array.
 
@@ -210,6 +210,11 @@ class ConvolveFFTW:
                 :attr:`data_fft` workspace. If False, the
                 :attr:`data_fft` *is* the returned array; if True,
                 returned array is a copy.
+            shift (:obj:`bool`, optional):
+                Before computing, use ``numpy.fft.iffshift` to shift
+                the spatial coordinates of the image such that the 0
+                frequency component of the FFT is shifted to the
+                center of the image.
 
         Returns:
             `numpy.ndarray`_: The FFT of the provided data.
@@ -226,7 +231,7 @@ class ConvolveFFTW:
         if data.dtype.type is not np.float64:
             raise TypeError('Data must be of type numpy.float64.')
 
-        self.data.real[...] = data
+        self.data.real[...] = np.fft.ifftshift(data) if shift else data
         self.dfft()
         return self.data_fft.copy() if copy else self.data_fft
         
@@ -313,11 +318,8 @@ def smear(v, beam, beam_fft=False, sb=None, sig=None, cnvfftw=None):
     _cnv = convolve_fft if cnvfftw is None else cnvfftw
 
     # Pre-compute the beam FFT
-    if beam_fft:
-        bfft = beam
-    else:
-        bfft = np.fft.ifftshift(beam)
-        bfft = np.fft.fftn(bfft) if cnvfftw is None else cnvfftw.fft(bfft, copy=True)
+    bfft = beam if beam_fft else (np.fft.fftn(np.fft.ifftshift(beam))
+                                    if cnvfftw is None else cnvfftw.fft(beam, shift=True))
 
     # Get the first moment of the beam-smeared intensity distribution
     mom0 = None if sb is None else _cnv(sb, bfft, kernel_fft=True)

--- a/barfit/tests/test_beam.py
+++ b/barfit/tests/test_beam.py
@@ -5,16 +5,18 @@ import numpy
 
 from astropy import convolution
 
-from barfit.models.beam import convolve_fft, gauss2d_kernel, ConvolveFFTW
+from barfit.models import beam
+from barfit.models import oned
+from barfit.models.geometry import projected_polar
 
 def test_convolve():
     """
     Test that the results of the convolution match astropy.
     """
-    synth = gauss2d_kernel(73, 3.)
+    synth = beam.gauss2d_kernel(73, 3.)
     astsynth = convolution.convolve_fft(synth, synth, fft_pad=False, psf_pad=False,
                                         boundary='wrap')
-    intsynth = convolve_fft(synth, synth)
+    intsynth = beam.convolve_fft(synth, synth)
     assert numpy.all(numpy.isclose(astsynth, intsynth)), 'Difference wrt astropy convolution'
 
 
@@ -27,26 +29,26 @@ def test_beam():
     kernels are treated differently.
     """
     n = 50
-    beam = gauss2d_kernel(n, 3.)
-    _beam = convolve_fft(beam, beam)
-    assert numpy.argmax(beam) == numpy.argmax(_beam), \
+    synth = beam.gauss2d_kernel(n, 3.)
+    _synth = beam.convolve_fft(synth, synth)
+    assert numpy.argmax(synth) == numpy.argmax(_synth), \
             'Beam kernel shifted the center for an even image size.'
 
     n = 51
-    beam = gauss2d_kernel(n, 3.)
-    _beam = convolve_fft(beam, beam)
-    assert numpy.argmax(beam) == numpy.argmax(_beam), \
+    synth = beam.gauss2d_kernel(n, 3.)
+    _synth = beam.convolve_fft(synth, synth)
+    assert numpy.argmax(synth) == numpy.argmax(_synth), \
             'Beam kernel shifted the center for an odd image size.'
 
 
 def test_fft():
-    synth = gauss2d_kernel(73, 3.)
+    synth = beam.gauss2d_kernel(73, 3.)
     synth_fft = numpy.fft.fftn(numpy.fft.ifftshift(synth))
-    _convolve_fft = ConvolveFFTW(synth.shape)
+    _convolve_fft = beam.ConvolveFFTW(synth.shape)
 
     # Compare numpy with direct vs. FFT kernel input
-    synth2 = convolve_fft(synth, synth)
-    _synth2 = convolve_fft(synth, synth_fft, kernel_fft=True)
+    synth2 = beam.convolve_fft(synth, synth)
+    _synth2 = beam.convolve_fft(synth, synth_fft, kernel_fft=True)
     assert numpy.allclose(synth2, _synth2), 'Difference if FFT is passed for numpy'
 
     # Compare numpy and FFTW with direct input
@@ -58,8 +60,61 @@ def test_fft():
     assert numpy.allclose(synth2, _synth2), 'Difference if FFT is passed for FFTW'
 
     # Compare numpy and FFTW with direct input and FFT output
-    synth2 = convolve_fft(synth, synth, return_fft=True)
+    synth2 = beam.convolve_fft(synth, synth, return_fft=True)
     _synth2 = _convolve_fft(synth, synth, return_fft=True)
     assert numpy.allclose(synth2, _synth2), 'Difference between numpy and FFTW'
 
+
+def test_smear():
+
+    n = 51
+    x = numpy.arange(n, dtype=float)[::-1] - n//2
+    y = numpy.arange(n, dtype=float) - n//2
+    x, y = numpy.meshgrid(x, y)
+
+    r, theta = projected_polar(x, y, *numpy.radians([45., 30.]))
+
+    rc = oned.HyperbolicTangent(par=numpy.array([100., 1.]))
+    sig = oned.Exponential(par=numpy.array([100., 20.]))
+    sb = oned.Sersic1D(par=numpy.array([1., 10., 1.]))
+
+    sb_field = sb.sample(r)
+    vel_field = rc.sample(r)*numpy.cos(theta)
+    sig_field = sig.sample(r)
+
+    cnvlv = beam.ConvolveFFTW(x.shape)
+    synth = beam.gauss2d_kernel(n, 3.)
+
+#    import time
+#    t = time.perf_counter()
+    vel_smear = beam.smear(vel_field, synth)[1]
+#    nptime = time.perf_counter() - t
+#    t = time.perf_counter()
+    _vel_smear = beam.smear(vel_field, synth, cnvfftw=cnvlv)[1]
+#    fwtime = time.perf_counter() - t
+#    print('{0:5.2f} {1:5.2f} {2:5.2f}'.format(nptime*1e3, fwtime*1e3, nptime/fwtime))
+
+    assert numpy.allclose(vel_smear, _vel_smear), 'Velocity-field-only convolution difference.'
+
+#    t = time.perf_counter()
+    sb_smear, vel_smear, _ = beam.smear(vel_field, synth, sb=sb_field)
+#    nptime = time.perf_counter() - t
+#    t = time.perf_counter()
+    _sb_smear, _vel_smear, _ = beam.smear(vel_field, synth, sb=sb_field, cnvfftw=cnvlv)
+#    fwtime = time.perf_counter() - t
+#    print('{0:5.2f} {1:5.2f} {2:5.2f}'.format(nptime*1e3, fwtime*1e3, nptime/fwtime))
+    assert numpy.allclose(sb_smear, _sb_smear), 'SB+Vel convolution difference in SB.'
+    assert numpy.allclose(vel_smear, _vel_smear), 'SB+Vel convolution difference in Vel.'
+
+#    t = time.perf_counter()
+    sb_smear, vel_smear, sig_smear = beam.smear(vel_field, synth, sb=sb_field, sig=sig_field)
+#    nptime = time.perf_counter() - t
+#    t = time.perf_counter()
+    _sb_smear, _vel_smear, _sig_smear = beam.smear(vel_field, synth, sb=sb_field, sig=sig_field,
+                                                   cnvfftw=cnvlv)
+#    fwtime = time.perf_counter() - t
+#    print('{0:5.2f} {1:5.2f} {2:5.2f}'.format(nptime*1e3, fwtime*1e3, nptime/fwtime))
+    assert numpy.allclose(sb_smear, _sb_smear), 'SB+Vel+Sig convolution difference in SB.'
+    assert numpy.allclose(vel_smear, _vel_smear), 'SB+Vel+Sig convolution difference in vel.'
+    assert numpy.allclose(sig_smear, _sig_smear), 'SB+Vel+Sig convolution difference in sig.'
 

--- a/barfit/tests/test_beam.py
+++ b/barfit/tests/test_beam.py
@@ -84,36 +84,30 @@ def test_smear():
 
     cnvlv = beam.ConvolveFFTW(x.shape)
     synth = beam.gauss2d_kernel(n, 3.)
+    synth_fft = cnvlv.fft(synth, shift=True)
 
-#    import time
-#    t = time.perf_counter()
     vel_smear = beam.smear(vel_field, synth)[1]
-#    nptime = time.perf_counter() - t
-#    t = time.perf_counter()
     _vel_smear = beam.smear(vel_field, synth, cnvfftw=cnvlv)[1]
-#    fwtime = time.perf_counter() - t
-#    print('{0:5.2f} {1:5.2f} {2:5.2f}'.format(nptime*1e3, fwtime*1e3, nptime/fwtime))
-
     assert numpy.allclose(vel_smear, _vel_smear), 'Velocity-field-only convolution difference.'
 
-#    t = time.perf_counter()
+    vel_smear = beam.smear(vel_field, synth)[1]
+    _vel_smear = beam.smear(vel_field, synth_fft, beam_fft=True)[1]
+    assert numpy.allclose(vel_smear, _vel_smear), \
+            'Velocity-field difference w/ vs. w/o precomputing the beam FFT for numpy.'
+
+    vel_smear = beam.smear(vel_field, synth, cnvfftw=cnvlv)[1]
+    _vel_smear = beam.smear(vel_field, synth_fft, beam_fft=True, cnvfftw=cnvlv)[1]
+    assert numpy.allclose(vel_smear, _vel_smear), \
+            'Velocity-field difference w/ vs. w/o precomputing the beam FFT for ConvolveFFTW.'
+
     sb_smear, vel_smear, _ = beam.smear(vel_field, synth, sb=sb_field)
-#    nptime = time.perf_counter() - t
-#    t = time.perf_counter()
     _sb_smear, _vel_smear, _ = beam.smear(vel_field, synth, sb=sb_field, cnvfftw=cnvlv)
-#    fwtime = time.perf_counter() - t
-#    print('{0:5.2f} {1:5.2f} {2:5.2f}'.format(nptime*1e3, fwtime*1e3, nptime/fwtime))
     assert numpy.allclose(sb_smear, _sb_smear), 'SB+Vel convolution difference in SB.'
     assert numpy.allclose(vel_smear, _vel_smear), 'SB+Vel convolution difference in Vel.'
 
-#    t = time.perf_counter()
     sb_smear, vel_smear, sig_smear = beam.smear(vel_field, synth, sb=sb_field, sig=sig_field)
-#    nptime = time.perf_counter() - t
-#    t = time.perf_counter()
     _sb_smear, _vel_smear, _sig_smear = beam.smear(vel_field, synth, sb=sb_field, sig=sig_field,
                                                    cnvfftw=cnvlv)
-#    fwtime = time.perf_counter() - t
-#    print('{0:5.2f} {1:5.2f} {2:5.2f}'.format(nptime*1e3, fwtime*1e3, nptime/fwtime))
     assert numpy.allclose(sb_smear, _sb_smear), 'SB+Vel+Sig convolution difference in SB.'
     assert numpy.allclose(vel_smear, _vel_smear), 'SB+Vel+Sig convolution difference in vel.'
     assert numpy.allclose(sig_smear, _sig_smear), 'SB+Vel+Sig convolution difference in sig.'


### PR DESCRIPTION
Bogus results were because I wasn't copying the numpy arrays properly.  This should fix `barfit.models.beam.smear`.  See the `test_smear` function in `barfit/tests/test_beam.py`.